### PR TITLE
Avoid logging to the *Messages* buffer.

### DIFF
--- a/orgtbl-show-header.el
+++ b/orgtbl-show-header.el
@@ -31,7 +31,8 @@
 (defun orgtbl-show-header-of-current-column ()
   "In a table, show the header of the column the point is in."
   (interactive)
-  (message "%s" (substring-no-properties (org-table-get 1 nil))))
+  (let ((message-log-max nil))
+    (message "%s" (substring-no-properties (org-table-get 1 nil)))))
 
 (defadvice org-table-next-field (after orgtbl-show-header-after-next-field last)
   "Call `orgtbl-show-header-of-current-column`."


### PR DESCRIPTION
- orgtbl-show-header.el (orgtbl-show-header-of-current-column): bind message-log-max to nil.
